### PR TITLE
Correction des liens de la TOC

### DIFF
--- a/TestGitHubEmailService.md
+++ b/TestGitHubEmailService.md
@@ -1,0 +1,7 @@
+
+# Receiving email notifications for pushes to a repository
+
+Ce fichier n’existe que pour tester l’envoi de mails de notification.
+
+<https://help.github.com/articles/receiving-email-notifications-for-pushes-to-a-repository/>
+

--- a/generation/make-toc.py
+++ b/generation/make-toc.py
@@ -92,9 +92,13 @@ Version de travail du 2016/01/02
             TOC = '%s\n**%d.%d** **%s** %s %s' % ( TOC, nbsemaine, nbchapitre, dataMap[ "titre" ][ 0 ], NIVEAU, AUTEUR )
         if( dataMap[ "statut" ] not in [ u"Pas publié" ] ):
             LINKS = []
-            for key, URL in sorted( dataMap[ "url" ].iteritems() ):
-                LINKS += [ "[%s](../%d%0.2d/%s)" % ( key, nbsemaine, nbchapitre, URL ) ]
+            fileTypes = [ "cours-html", "cours-pdf", "dias-compact" ]
+            for fileType in fileTypes:
+                if fileType in dataMap[ "url" ]:
+                    fileName = dataMap[ "url" ][ fileType ]
+                    LINKS += [ "[%s](../%d%0.2d/%s)" % ( fileType, nbsemaine, nbchapitre, fileName ) ]
             LINKS = ' '.join( LINKS )
+            print "⇒ " + LINKS
             TOC = '%s %s' % ( TOC, LINKS )
 
         TOC = '%s %s' % ( TOC, '  ' )


### PR DESCRIPTION
J’ai modifié la génération des liens de la TOC.

Avant cette modif, les liens étaient générés dans l’ordre alphabétique.

Maintenant, les liens sont générés en suivant l’ordre donné par le dictionnaire “fileTypes” à la ligne 95.

Cette modification impose que les labels des URL soient identiques dans les fichiers “infos.yaml” et dans le script “make-toc.py”. Donc il faudra corriger les fichiers “infos.yaml” qui ne respectent pas les noms standards.
