### PR TITLE
Harmonisation des en-têtes des fichiers Markdown.

### DIFF
--- a/cours/103/binaire.md
+++ b/cours/103/binaire.md
@@ -1,10 +1,8 @@
 % Nombres et champs de bits
-% [Pierre-Yves Rochat](mailto:pyr@pyr.ch), EPFL
-% et [Yves Tiecoura](mailto:tiecouray@yahoo.fr), INP-HB
+% [Pierre-Yves Rochat](mailto:pyr@pyr.ch), EPFL<br/>et [Yves Tiecoura](mailto:tiecouray@yahoo.fr), INP-HB
 % rév 2015/12/25
 
-Document en cours de relecture, rév du 2015/12/13
-Ce document n’est pas à jour, il n’a pas encore été adapté aux modifications des diapositives pour la vidéo.
+> Ce document n’est pas à jour, il n’a pas encore été adapté aux modifications des diapositives pour la vidéo.
 
 
 ## Bascules et registres ##

--- a/cours/104/microcontroleur.md
+++ b/cours/104/microcontroleur.md
@@ -1,13 +1,11 @@
-**Introduction au microcontrôleur**
-==================================
+% Introduction au microcontrôleur
+% [Pierre-Yves Rochat](mailto:pyr@pyr.ch), EPFL
+% rév 2016/01/30
 
-## [Pierre-Yves Rochat](mailto:pyr@pyr.ch), EPFL
-
-> Document en cours de relecture, rév du 2016/01/30
 
 ## Système informatique dans un circuit intégré ##
 
-Pour commander des enseignes ou des afficheurs à LED, c'est très souvent un **microcontrôleur** qui est utilisé. 
+Pour commander des enseignes ou des afficheurs à LED, c'est très souvent un **microcontrôleur** qui est utilisé.
 
 Nous somme tous familier avec les systèmes informatique, à commencer par nos ordinateurs de bureau et nos *smartphones*. A l'intérieur de tout système informatique se trouvent a moins :
 
@@ -25,7 +23,7 @@ Un microcontrôleur est aussi un système informatique. Sa particularité est qu
 * la mémoire morte contient généralement de 1 kB à quelques centaines de kB.
 * le processeur est cadencé à des fréquences de quelques MHz ou dizaines de MHz. Il ne consomme généralement qu'une fraction de Watt. Son jeu d'instructions est plus simple.
 * la mémoire vivre est généralement très limitée : de quelques centaines de Bytes à quelques dizaines de kB, selon les modèles.
-* les circuits d'entrée-sortie sont simplement des entrées logiques (pour lire une valeur binaire, par exemple un interrupteur) et des sorties logiques (capables de fournir quelques mA, par exemple pour commander une LED). 
+* les circuits d'entrée-sortie sont simplement des entrées logiques (pour lire une valeur binaire, par exemple un interrupteur) et des sorties logiques (capables de fournir quelques mA, par exemple pour commander une LED).
 
 L'intérêt des microcontrôleurs est leur coût très faible (parfois moins d'un Euro), leur consommation de courant très limitée (quelques dizaines de mA) et leur taille très réduite (un seul circuit intégré). Ils sont donc utilisés dans de très nombreuses applications.
 

--- a/cours/202/C-Arduino.md
+++ b/cours/202/C-Arduino.md
@@ -1,7 +1,7 @@
 % Programmation en C-Arduino
 % [Pierre-Yves Rochat](mailto:pyr@pyr.ch), EPFL
+% rév 2016/01/04
 
-Document en cours de relecture, version du 2016/01/04
 
 ## Différentes significations du mot Arduino ##
 

--- a/cours/305/seq-compteur.md
+++ b/cours/305/seq-compteur.md
@@ -1,6 +1,5 @@
 % Séquenceurs à compteurs
-% [Yves Tiecoura](mailto:tiecouray@yahoo.fr), INP-HB Yamoussoukro
-% et [Pierre-Yves Rochat](mailto:pyr@pyr.ch), EPFL
+% [Yves Tiecoura](mailto:tiecouray@yahoo.fr), INP-HB Yamoussoukro<br/>et [Pierre-Yves Rochat](mailto:pyr@pyr.ch), EPFL
 % rév 2015/11/11
 
 

--- a/generation/md2pdf.sh
+++ b/generation/md2pdf.sh
@@ -34,6 +34,8 @@ function HTML2PDF
 
     if [[ "$OSTYPE" == darwin14 ]]; then
         open $PDF_FILE
+    elif [[ "$OSTYPE" == linux-gnu ]]; then
+        xdg-open $PDF_FILE
     fi
 }
 

--- a/generation/open-pdf.sh
+++ b/generation/open-pdf.sh
@@ -1,0 +1,71 @@
+ #!/bin/bash
+
+# ##########
+#
+# open-pdf.sh ⇒ ouvre les fichiers PDF des cours pour vérifier qu’ils sont OK manuellement
+#
+#
+# Nicolas Jeanmonod, février 2016
+#
+# ##########
+
+
+function OPENPDF
+{
+    if [[ "$OSTYPE" == darwin14 ]]; then
+        open $PDF_FILE
+    elif [[ "$OSTYPE" == linux-gnu ]]; then
+        xdg-open $PDF_FILE
+    fi
+}
+
+function DO_ALL
+{
+    pwd
+    CSS_FILE=../../statiques/style.css
+    MD_FILE=$CODE.md
+    HTML_FILE=$CODE.html
+    PDF_FILE=$CODE.pdf
+    echo "ouverture de $PDF_FILE"
+    OPENPDF
+}
+
+
+
+
+
+if [[ "$#" == "0" ]]; then
+
+    # Si aucun argument n’est indiqué, on transforme tous les chapitres.
+    cd ../cours/
+    INFOS=`find . -name infos.yaml`
+    INFOS=(${INFOS//:/ })
+    for INFO in "${INFOS[@]}"
+    do
+        echo $INFO
+        STATUT=`awk -F 'statut:[ ]+' '{ print $2 }' $INFO`
+        echo $STATUT
+        if [[ "$STATUT" == *"Pas publié"* ]]; then
+            :
+        else
+            CODE=`awk -F 'code:[ ]+' '{ print $2 }' $INFO`
+            echo $CODE
+            DIR=$(dirname "${INFO}")
+            echo "${DIR}"
+            cd ${DIR}
+            DO_ALL
+            cd ..
+        fi
+        echo "*****"
+    done
+else
+
+    # Si un argument est indiqué, on ne transforme que ce chapitre.
+    CHAP_NB=$1
+    cd ../cours/$CHAP_NB
+    CODE=`awk -F 'code:[ ]+' '{ print $2 }' infos.yaml`
+    echo $CODE
+    DO_ALL
+fi
+
+


### PR DESCRIPTION
- Le fichier `104/microcontroleur.md` n’avait pas les en-têtes que j’ai mises hier. Ça serait bien que tu vérifies que le texte est OK également et que tes dernières modifications sont bien présentes.
- Pour les fichiers `103/binaire.md` et `305/seq-compteur.md`, j’ai mis les 2 profs dans le même champ, mais séparés par un `<br/>`. 
- Pour le fichier `202/C-Arduino.md`, j’ai mis la date de modif dans l’en-tête.
