### PR TITLE
remplacé gremlins dans cours/502/timers.md + correction bug espace 

### DIFF
--- a/cours/502/timers.md
+++ b/cours/502/timers.md
@@ -123,7 +123,7 @@ int main() {
   TACTL0 = TASSEL_2 + ID_3 + MC_2;
   while (1) { // Boucle infinie
     if (TACTL0 & TAIFG) {
-      TACTL0 &=~TAIFG;
+      TACTL0 &= ~TAIFG;
       P1OUT ^= (1<<0); // Inversion LED
     }
   }
@@ -156,9 +156,9 @@ int main() {
   TACCR0 = 62500; // 62500 * 8 us = 500 ms
   while (1) { // Boucle infinie
     if (TACCTL0 & CCIFG) {
-      TACCTL0 &=~CCIFG;
+      TACCTL0 &= ~CCIFG;
       TACCR0 += 62500;
-      P1OUT ^⁼ (1<<0); // Inversion LED
+      P1OUT ^= (1<<0); // Inversion LED
     }
   }
 }

--- a/generation/open-pdf.sh
+++ b/generation/open-pdf.sh
@@ -44,11 +44,13 @@ if [[ "$#" == "0" ]]; then
     do
         echo $INFO
         STATUT=`awk -F 'statut:[ ]+' '{ print $2 }' $INFO`
+        STATUT=`echo $STATUT`
         echo $STATUT
         if [[ "$STATUT" == *"Pas publié"* ]]; then
             :
         else
             CODE=`awk -F 'code:[ ]+' '{ print $2 }' $INFO`
+            CODE=`echo $CODE`
             echo $CODE
             DIR=$(dirname "${INFO}")
             echo "${DIR}"
@@ -64,6 +66,7 @@ else
     CHAP_NB=$1
     cd ../cours/$CHAP_NB
     CODE=`awk -F 'code:[ ]+' '{ print $2 }' infos.yaml`
+    CODE=`echo $CODE`
     echo $CODE
     DO_ALL
 fi


### PR DESCRIPTION
Il y avait un gremlins (un caractère bizarre) qui ressemble à un = mais qui n’en était pas un dans le fichier `cours/502/timers.md` à la ligne 161.

Dans le même fichier, j’ai aussi ajouté des espaces avant les négations ~ (lignes 126 et 159)

Pour le fichier `generation/open-pdf.sh`, j’ai juste supprimé les retours à la ligne inutiles affichés par le script lorsqu’on l’exécute.
