### PR TITLE
corrections 106/microcontroleur et 505/matrice-mux

### DIFF
--- a/cours/106/microcontroleur-dia.md
+++ b/cours/106/microcontroleur-dia.md
@@ -55,7 +55,7 @@ Pierre-Yves Rochat
 <h1 class="en_tete">Le microcontrôleur</h1>
 <img src="./images/uC-sys-info.svg" style="top:7cm; left:11cm; width:38cm; ">
 <div style="top: 26cm; left: 3cm; font-size: 48pt; line-height: 1.2;">
-<!-- 2 -->* Un microcontrôleur est circuit intégré contenant un système informatique 
+<!-- 2 -->* Un microcontrôleur est un circuit intégré contenant un système informatique
 </div>
 </section>
 
@@ -64,7 +64,7 @@ Pierre-Yves Rochat
 <!-- A -->
 <h1 class="en_tete">De nombreuses familles de microcontrôleurs</h1>
 <div style="top: 8cm; left: 3cm; font-size: 48pt;">
-* De nombreux fabricants 
+* De nombreux fabricants
 </div>
 <!-- 234567 --><img src="./images/microchip-atmel-logo.png" style="top:11cm; left:3cm; width:19cm; ">
 <!-- 234567 --><img src="./images/nxp-logo.png" style="top:11.7cm; left:20cm; width:5cm; ">
@@ -72,9 +72,9 @@ Pierre-Yves Rochat
 <!-- 234567 --><img src="./images/ti-logo.png" style="top:9.2cm; left:36cm; width:11cm; ">
 <!-- 234567 --><img src="./images/cypress-logo.png" style="top:10.8cm; left:49cm; width:8cm; ">
 <!-- 34567 --><div style="top: 16.5cm; left: 3cm; font-size: 48pt; line-height: 1.3;">
-<!-- 34567 -->* Mémoire morte de 1kB à des MB
-<!-- 4567 -->* Mémoire vive de quelques octets à des centaines de kB
-<!-- 567 -->* De quelques broches à des centaines de broches d'entrées-sorties
+<!-- 34567 -->* Mémoire morte de 1 ko à des Mo
+<!-- 4567 -->* Mémoire vive de quelques octets à des centaines de ko
+<!-- 567 -->* De quelques broches à des centaines de broches d’entrées-sorties
 <!-- 34567 --></div>
 <!-- 67 --><img src="./images/dil14.png" style="top:25.0cm; left:7cm; width:9cm; ">
 <!-- 67 --><img src="./images/smd16.png" style="top:25.0cm; left:19cm; width:7cm; ">
@@ -95,14 +95,14 @@ Pierre-Yves Rochat
 <!-- A -->
 <h1 class="en_tete">Mise en œuvre matérielle et logicielle</h1>
 <div style="top: 8cm; left: 3cm; font-size: 48pt;">
-* Un composant électronique 
-<!-- 23456 -->* => mise en œuvre matérielle
-<!-- 3456 -->* => compétence d'un électronicien !
+* Un composant électronique
+<!-- 23456 -->* ⇒ mise en œuvre matérielle
+<!-- 3456 -->* ⇒ compétence d’un électronicien !
 </div>
 <!-- 456 --><div style="top: 20cm; left: 3cm; font-size: 48pt;">
 <!-- 456 -->* Un système informatique programmable
-<!-- 56 -->* => mise en œuvre logicielle
-<!-- 6 -->* => compétence d'un informaticien !
+<!-- 56 -->* ⇒ mise en œuvre logicielle
+<!-- 6 -->* ⇒ compétence d’un informaticien !
 <!-- 456 --></div>
 </section>
 
@@ -131,7 +131,7 @@ Pierre-Yves Rochat
 
 <section>
 <!-- A -->
-<h1 class="en_tete">Programmation d'un microcontrôleur</h1>
+<h1 class="en_tete">Programmation d’un microcontrôleur</h1>
 <img src="./images/pc-prog.svg" style="top:9.0cm; left:5cm; width:13cm; ">
 <!-- 23 --><img src="./images/launchpad.jpg" style="top:9.0cm; left:20cm; width:17cm; ">
 <!-- 3 --><img src="./images/Uno.jpg" style="top:12.0cm; left:39cm; width:19cm; ">

--- a/cours/106/microcontroleur.md
+++ b/cours/106/microcontroleur.md
@@ -3,7 +3,7 @@
 % rév 2016/07/07
 
 
-Pour commander des enseignes ou des afficheurs à LED, c’est très souvent un **microcontrôleur** qui est utilisé. Voyons de quoi il s'agit.
+Pour commander des enseignes ou des afficheurs à LED, c’est très souvent un **microcontrôleur** qui est utilisé. Voyons de quoi il s’agit.
 
 ## Système informatique ##
 
@@ -11,40 +11,40 @@ Nous sommes tous familiers avec les systèmes informatiques, à commencer par no
 
 * Un **processeur**, qui exécute les instructions. Il est cadencé par une horloge (H).
 * Une **mémoire morte** (ROM : *Read Only Memory*) qui contient des instructions. Son contenu est permanent : il reste intact lorsque le système n’est plus alimenté.
-* Une **mémoire vivre** (RAM : *Random Access Memory*, qui permet de stocker des données. Son contenu est perdu lorsque le courant est coupé.
-* Des circuits d’**Entrée-Sortie** (I/O : *Input/Output*). Ce sont les circuits qui permettent l’interaction avec l’extérieur : clavier, souris, écran, mémoire externe, imprimante, etc.
+* Une **mémoire vive** (RAM : *Random Access Memory*, qui permet de stocker des données. Son contenu est perdu lorsque le courant est coupé.
+* Des circuits d’**entrée-sortie** (I/O : *Input/Output*). Ce sont les circuits qui permettent l’interaction avec l’extérieur : clavier, souris, écran, mémoire externe, imprimante, etc.
 
-Des lignes électriques, appelées *bus* relient ces éléments entre eux. Voici un schéma-bloc d'un système informatique :
+Des lignes électriques, appelées *bus* relient ces éléments entre eux. Voici un schéma-bloc d’un système informatique :
 
 ![Architecture d’un système informatique](images/architecture-sys-info.svg "Architecture d’un système informatique"){ width=90% }
 
 ## Microcontrôleur ##
 
-Un **microcontrôleur** est aussi un système informatique. Sa particularité est qu’il est contenu dans un seul circuit intégré. L’architecture est la même que celle présentée sur la figure. Par rapport à une carte mère de PC, les éléments qui constituent un microcontrôleur sont généralement plus simples, moins performants, leur capacité est plus limitée :
+Un **microcontrôleur** est aussi un système informatique. Sa particularité est qu’il est contenu dans un seul circuit intégré. L’architecture est la même que celle présentée sur la figure. Par rapport à une carte mère d’ordinateur, les éléments qui constituent un microcontrôleur sont généralement plus simples, moins performants, leur capacité est plus limitée :
 
-* La mémoire morte contient généralement de un à quelques centaines de kB.
+* La mémoire morte contient généralement de un à quelques centaines de ko.
 * Le processeur est cadencé à des fréquences de quelques mégahertz ou dizaines de mégahertz. Il ne consomme généralement qu’une fraction de watt. Son jeu d’instructions est plus simple.
-* La mémoire vive est généralement très limitée : de quelques centaines d'octets (B = byte) à quelques dizaines de kB selon les modèles.
+* La mémoire vive est généralement très limitée : de quelques centaines d’octets (ou en anglais *byte*, abrégé “B”) à quelques dizaines de ko selon les modèles.
 * Les circuits d’entrée-sortie sont simplement des entrées logiques, pour lire une valeur binaire, comme par exemple un interrupteur, ainsi que des sorties logiques, capables de fournir quelques milliampères, par exemple pour commander une LED.
 
-L’intérêt des microcontrôleurs est leur coût très faible, souvent moins d’un euro), leur consommation de courant limitée à quelques de milliampères et leur taille très réduite, vu qu'il s'agit d'un seul circuit intégré. Ils sont donc utilisés dans de très nombreuses applications.
+L’intérêt des microcontrôleurs est leur coût très faible, souvent moins d’un euro, leur consommation de courant limitée à quelques de milliampères et leur taille très réduite, vu qu’il s’agit d’un seul circuit intégré. Ils sont donc utilisés dans de très nombreuses applications.
 
-Bien que des microcontrôleurs existent depuis les années 1970, ils se sont développés de manière spectaculaire depuis quelques années. Les microcontrôleurs actuels contiennent de la mémoire __*Flash*__, qui rendent facile l'écriture du programme qui doit s'exécuter
+Bien que des microcontrôleurs existent depuis les années 1970, ils se sont développés de manière spectaculaire depuis quelques années. Les microcontrôleurs actuels contiennent de la mémoire __*flash*__, qui facilite l’écriture du programme qui doit s’exécuter.
 
-Alors qu’il était encore complexe et coûteux de mettre en œuvre un microcontrôleur au début des années 2000, cette tâche est maintenant beaucoup plus simple et ne nécessite que du matériel très peu coûteux. Les microcontrôleurs sont donc devenus des composants électroniques incontournables, modifiant profondément la manière de concevoir les circuits électroniques.
+Alors qu’il était encore complexe et coûteux de mettre en œuvre un microcontrôleur au début des années 2000, cette tâche est maintenant beaucoup plus simple et ne nécessite que du matériel très peu coûteux. Les microcontrôleurs sont donc devenus des composants électroniques incontournables, modifiant profondément la manière de concevoir les circuits électroniques.
 
 ## De nombreuses familles ##
 
-Beaucoup de fabricants proposent des microcontrôleurs (Microchip-Atmel, Texas-Instrument, NXP, ST-micro, Cypress, etc). Chaque fabricant offre souvent plusieurs familles de microcontrôleurs (PIC, dsPIC chez Microchip, AVR, AVR32, ARM chez Atmel, MSP430, MSP432 chez Texas Instruments, etc.) Chaque famille comporte souvent des dizaines, voire des centaines de modèles, qui diffèrent les uns des autres principalement par les tailles mémoires (RAM et ROM) et le nombre de broches d’entrée-sortie.
+Beaucoup de fabricants proposent des microcontrôleurs (Microchip-Atmel, Texas-Instrument, NXP, ST-micro, Cypress, etc.). Chaque fabricant offre souvent plusieurs familles de microcontrôleurs (PIC, dsPIC chez Microchip, AVR, AVR32, ARM chez Atmel, MSP430, MSP432 chez Texas Instruments, etc.) Chaque famille comporte souvent des dizaines, voire des centaines de modèles, qui diffèrent les uns des autres principalement par les tailles mémoires (RAM et ROM) et le nombre de broches d’entrée-sortie.
 
 À titre d’exemple, le processeur MSP430G2253 de Texas Instruments contient :
 
-* Un processeur 16 bits, avec une centaine d’instructions, cadencé au maximum à 16 MHz, avec 16 registres de 16 bits.
-* Une mémoire morte de type *flash* (technologie similaire à celle des clés USB) de 16 kB. Cette mémoire peut être effacée et écrite un très grand nombre de fois.
-* Une mémoire vive de 512 B.
-* 16 broches d’entrée-sorties. Huit d’entre-elles peuvent être connectées à un convertisseur analogique-numérique de 10 bits de résolution. Certaines de ces broches ont également d’autres fonctions spécifiques (génération de signaux, capture d’événements, utilisation d’un quartz, etc.)
+* Un processeur 16 bits, avec une centaine d’instructions, cadencé au maximum à 16 MHz, avec 16 registres de 16 bits.
+* Une mémoire morte de type *flash* (technologie similaire à celle des clés USB) de 16 ko. Cette mémoire peut être effacée et écrite un très grand nombre de fois.
+* Une mémoire vive de 512 o.
+* 16 broches d’entrée-sorties. Huit d’entres-elles peuvent être connectées à un convertisseur analogique-numérique de 10 bits de résolution. Certaines de ces broches ont également d’autres fonctions spécifiques (génération de signaux, capture d’événements, utilisation d’un quartz, etc.).
 
-Les microcontrôleurs de la famille MSP430G sont disponible dans plusieurs boîtiers, dont le DIL20 (Dual-In-Line 20 pins), facile à mettre en œuvre. Voici son brochage :
+Les microcontrôleurs de la famille MSP430G sont disponibles dans plusieurs boîtiers, dont le DIL20 (*Dual-In-Line* 20 pins), facile à mettre en œuvre. Voici son brochage :
 
 ![Brochage du MSP430G2553](images/pinout-msp430-20pin.svg "Brochage du MSP430G2553"){ width=35% }
 
@@ -56,35 +56,35 @@ Un microcontrôleur est à la fois un **composant électronique** et un **systè
 
 Chaque broche est désignée par un ou plusieurs noms. Identifions les trois groupes de broches indispensables à la réalisation d’un premier montage fonctionnel à microcontrôleur :
 
-* les alimentations : Gnd et +3 V
+* les alimentations : Gnd et +3 V
 * les broches de programmation : Rst et TEST
-* les broches d’entrées-sorties pour l’application proprement dite, c'est à dire toutes les autres broches.
+* les broches d’entrées-sorties pour l’application proprement dite, c’est-à-dire toutes les autres broches.
 
-Les microcontrôleurs sont presque toujours réalisés en technologie **CMOS** et nécessitent une alimentation unique. Les MSP430 acceptent une tension comprise entre 1,8 et 3,6 V. Deux piles AA ou AAA de 1,5 V montées en série peuvent donc convenir. La borne négative de l’alimentation est souvent désignée par *Gnd* (*Ground* : masse). C’est la broche 20 du MSP430G2553. La borne positive est notée *3 V*, c’est la broche 1.
+Les microcontrôleurs sont presque toujours réalisés en technologie **CMOS** et nécessitent une alimentation unique. Les MSP430 acceptent une tension comprise entre 1,8 et 3,6 V. Deux piles AA ou AAA de 1,5 V montées en série peuvent donc convenir. La borne négative de l’alimentation est souvent désignée par *Gnd* (*Ground* : masse). C’est la broche 20 du MSP430G2553. La borne positive est notée *3 V*, c’est la broche 1.
 
-La fonction *Rst* ou *Reset* est câblée sur la broche 16. Le *Rst* est une entrée du circuit. Notez la barre sur son nom : cela signifie que cette entrée est active à 0. On le note aussi parfois avec le signe `/` (slash) précédent le nom : */Rst*. C’est une bonne habitude de mettre en évidence qu’un signal est actif à 0. Il sera nécessaire de fixer à l’état 1 la broche *RST* pour le fonctionnement normal du microcontrôleur. C’est une résistance reliée au *+3 V* qui joue ce rôle. On parle de résistance de tirage (en anglais *pull-up* : tirer vers le haut). Une valeur d’environ 47 kΩ convient dans ce cas.
+La fonction *Rst* ou *Reset* est câblée sur la broche 16. Le *Rst* est une entrée du circuit. Notez la barre sur son nom : cela signifie que cette entrée est active à 0. On le note aussi parfois avec le signe barre oblique (ou *slash*) `/` précédant le nom : */Rst*. C’est une bonne habitude de mettre en évidence qu’un signal est actif à 0. Il sera nécessaire de fixer à l’état 1 la broche *RST* pour le fonctionnement normal du microcontrôleur. C’est une résistance reliée au *+3 V* qui joue ce rôle. On parle de résistance de tirage (en anglais *pull-up* : tirer vers le haut). Une valeur d’environ 47 kΩ convient dans ce cas.
 
-La programmation des MSP430 peut se faire par l’intermédiaire de deux signaux : le *RST* et un signal nommé *TEST* (broche 17). Il n’est pas nécessaire de comprendre le rôle exact de ce signal. Il est généré par le logiciel de programmation qui s’exécute sur un PC, par exemple *Code Composer Studio* ou *Energia*. Il est transmis par un programmateur, par exemple celui inclus dans le *LaunchPad MSP430*.
+La programmation des MSP430 peut se faire par l’intermédiaire de deux signaux : le *RST* et un signal nommé *TEST* (broche 17). Il n’est pas nécessaire de comprendre le rôle exact de ce signal. Il est généré par le logiciel de programmation qui s’exécute sur un ordinateur, par exemple *Code Composer Studio* ou *Energia*. Il est transmis par un programmateur, par exemple celui inclus dans le *LaunchPad MSP430*.
 
-Les autres broches du MSP430G2553 sont des entrées-sorties. Elles sont regroupées en 2 ports : P1 et P2. Ces deux ports sont complets : ils comportent chacun 8 broches. D’autres versions du MSP430 sont proposées en boîtier à 14 broches (DIL 14). Dans ce cas, les broches P2.0 à P2.5 n’existent pas.
+Les autres broches du MSP430G2553 sont des entrées-sorties. Elles sont regroupées en 2 ports : P1 et P2. Ces deux ports sont complets : ils comportent chacun 8 broches. D’autres versions du MSP430 sont proposées en boîtier à 14 broches (DIL 14). Dans ce cas, les broches P2.0 à P2.5 n’existent pas.
 
 Un microcontrôleur est un composant électronique. Il va trouver sa place dans un schéma électronique pour sa mise en œuvre :
 
 ![Schéma de mise en œuvre d’un microcontrôleur](images/schema-msp430.svg "Schéma de mise en œuvre d’un microcontrôleur"){ width=50% }
 
-Ce schéma est très simple. En plus du microcontrôleur, on y trouve une LED, connectée à la broche *P1.0*, avec sa résistance de limitation du courant reliée en série vers la masse. Notez la présence d’un condensateur de découplage entre le + et le -. Les électroniciens savent qu’il est utile pour filtrer l’alimentation. On peut dire qu’il est une petite réserve de charges électriques. Sa valeur est souvent de 100 nF. Il sera placé le plus près possible du circuit intégré.
+Ce schéma est très simple. En plus du microcontrôleur, on y trouve une LED, connectée à la broche *P1.0*, avec sa résistance de limitation du courant reliée en série vers la masse. Notez la présence d’un condensateur de découplage entre le + et le -. Les électroniciens savent qu’il est utile pour filtrer l’alimentation. On peut dire qu’il est une petite réserve de charges électriques. Sa valeur est souvent de 100 nF. Il sera placé le plus près possible du circuit intégré.
 
 L’entrée *Reset* est maintenue à l’état logique *1* par une résistance reliée à l’alimentation positive, appelée résistance de tirage. Les signaux *Reset* et *Test* sont reliés à un connecteur, comportant aussi des broches pour l’alimentation. C’est par ce connecteur que le microcontrôleur pourra être programmé.
 
 ## Réalisation d’un montage à microcontrôleur ##
 
-L’assemblage de composants électroniques se fait le plus souvent sur un circuit imprimé (**PBC** : *Printed Circuit Board*). Pour des montages de test, il est possible d’utiliser des techniques de montage sans soudure, tels que les plaques d’expérimentation, appelées en anglais *breadboard*.
+L’assemblage de composants électroniques se fait le plus souvent sur un circuit imprimé (**PCB** : *Printed Circuit Board*). Pour des montages de test, il est possible d’utiliser des techniques de montage sans soudure, tels que les plaques d’expérimentation, appelées en anglais *breadboard*.
 
 Voici un exemple de montage :
 
-![Mise en œuvre d'un MSP430 sur un Breadboard](images/MSP-2231-LED.svg "Mise en œuvre d'un MSP430 sur un Breadboard"){ width=90% }
+![Mise en œuvre d’un MSP430 sur un Breadboard](images/MSP-2231-LED.svg "Mise en œuvre d’un MSP430 sur un Breadboard"){ width=90% }
 
-Notez qu'un MSP430G2231 a été utilisé dans cet exemple, avec seulement 14 broches.
+Notez qu’un MSP430G2231 a été utilisé dans cet exemple, avec seulement 14 broches.
 
 ## Programmation d’un microcontrôleur ##
 
@@ -92,13 +92,13 @@ La programmation d’un microcontrôleur se fait à travers ses broches de progr
 
 Dans le cas du MSP430G, la carte LaunchPad contient un programmateur capable de générer les signaux *Reset* et *Test* nécessaires à la programmation.
 
-![Mise en œuvre d'un MSP430 sur un Breadboard](images/launchpad-prog.png "Mise en œuvre d'un MSP430 sur un Breadboard"){ width=60% }
+![Mise en œuvre d’un MSP430 sur un Breadboard](images/launchpad-prog.png "Mise en œuvre d’un MSP430 sur un Breadboard"){ width=60% }
 
-Il est aussi possible de programmer un microcontrôleur sans utiliser un programmateur. Dans ce cas, le microcontrôleur doit déjà avoir initialement été programmé avec un programme appelé *Bootloader*, contenu dans une partie de la mémoire du microcontrôleur. Ce programme est capable de recevoir un programme de l'extérieur et de le programmer dans une autre partie de la mémoire.
+Il est aussi possible de programmer un microcontrôleur sans utiliser un programmateur. Dans ce cas, le microcontrôleur doit déjà avoir initialement été programmé avec un programme appelé *Bootloader*, contenu dans une partie de la mémoire du microcontrôleur. Ce programme est capable de recevoir un programme de l’extérieur et de le programmer dans une autre partie de la mémoire.
 
-L'exemple le plus connu est la carte Arduino :
+L’exemple le plus connu est la carte Arduino :
 
-![Carte Arduino Uno](images/Uno.jpg "Carte Arduino Uno"){ width=40% }
+![Carte Arduino Uno](images/Uno.jpg "Carte Arduino UNO"){ width=40% }
 
 
 

--- a/cours/505/matrice-mux-dia.md
+++ b/cours/505/matrice-mux-dia.md
@@ -55,7 +55,7 @@ Pierre-Yves Rochat
 
 <section>
 <!-- A -->
-<h1 class="en_tete">Schéma d'un afficheur matriciel</h1>
+<h1 class="en_tete">Schéma d’un afficheur matriciel</h1>
 <img src="./images/aff-8x16.svg" style="top:7cm; left:1cm; width:35cm;" />
 <!-- 2 --><img src="./images/reg-ser-par-timing-s.svg" style="top:17cm; left:37cm; width:22cm;" />
 </section>
@@ -63,17 +63,17 @@ Pierre-Yves Rochat
 
 <section>
 <!-- A -->
-<h1 class="en_tete">Conséquence de l'augmentation du nombre de LEDs</h1>
+<h1 class="en_tete">Conséquence de l’augmentation du nombre de LED</h1>
 <div style="font-size:52pt; left:3cm; width:46cm; top:7cm;">
 * 32 x 32 pixels => 1024 sorties de registre
 <!-- 2345678 -->* 128 registres 8 bits 74HC595 et 1024 résistances
 <!-- 345678 -->* Trois fois plus pour une matrice RGB !
 <!-- 45786 -->* Registres 16 bits à sortie à courant constant SUM2016
-<!-- 5786 -->*  192 circuits intégrée et 192 résistances 
+<!-- 5786 -->*  192 circuits intégrés et 192 résistances
 </div>
 <!-- 678 --><div style="font-size:52pt; left:3cm; width:46cm; top:21cm;">
 <!-- 78 -->* Peut-on obtenir des schémas plus simples ?
-<!-- 8 -->* Avec le multiplexage temporel ! 
+<!-- 8 -->* Avec le multiplexage temporel !
 <!-- 678 --></div>
 </section>
 
@@ -94,7 +94,7 @@ Pierre-Yves Rochat
 
 <section>
 <!-- A -->
-<h1 class="en_tete">Schéma d'un afficheur matriciel multiplexé</h1>
+<h1 class="en_tete">Schéma d’un afficheur matriciel multiplexé</h1>
 <img src="./images/aff-4x8-mux.svg" style="top:6cm; left:4cm; width:35cm;" />
 <!-- 234 --><div style="font-size:52pt; left:40cm; width:18cm; top:8cm;">
 <!-- 234 --> Courants ?
@@ -134,15 +134,15 @@ Pierre-Yves Rochat
 <!-- A -->
 <h1 class="en_tete">Comparaisons des architectures</h1>
 <div style="font-size:52pt; left:3cm; width:56cm; top:7cm;">
-* Multiplexage par 2 : 
+* Multiplexage par 2 :
 <!-- 2345 -->* Multiplexage par 4 : compromis intéressant
-<!-- 345 -->* Multiplexage par 8 et 16 : afficheurs d'intérieur
+<!-- 345 -->* Multiplexage par 8 et 16 : afficheurs d’intérieur
 </div>
 <!-- 45 --><div style="font-size:52pt; left:3cm; width:56cm; top:16cm;">
 <!-- 45 -->* Facteurs de multiplexage plus importants : trop peu de luminosité
 <!-- 45 --></div>
 <!-- 5 --><div style="font-size:52pt; left:3cm; width:56cm; top:21cm;">
-<!-- 5 -->* Panne d'une LED peut entraîner des perturbations sur les LED voisines
+<!-- 5 -->* Panne d’une LED peut entraîner des perturbations sur les LED voisines
 <!-- 5 --></div>
 </section>
 
@@ -152,15 +152,15 @@ Pierre-Yves Rochat
 <h1 class="en_tete">Programme de commande</h1>
 <div style="font-size:52pt; left:3cm; width:56cm; top:7cm;">
 * Similaire à un afficheur non multiplexé
-<!-- 23 -->* Procédure pour un cycle d'affichage
-<!-- 3 -->* Base de temps donné pas cette procédure
+<!-- 23 -->* Procédure pour un cycle d’affichage
+<!-- 3 -->* Base de temps donné par cette procédure
 </div>
 </section>
 
 
 <section>
 <!-- A -->
-<h1 class="en_tete">Cycle d'affichage</h1>
+<h1 class="en_tete">Cycle d’affichage</h1>
 <div style="top: 7cm; left: 2.65cm; font-size: 36pt; line-height: 2; width:57.0cm;">
 ~~~~~~~ { .c .numberLines startFrom="1" }
 uint8_t matrice[4];

--- a/cours/505/matrice-mux.md
+++ b/cours/505/matrice-mux.md
@@ -7,77 +7,77 @@
 
 Le schéma classique d’un afficheur matriciel nécessite simplement une sortie de registre par LED, comme le rappelle ce schéma :
 
-![Afficheur 8×16 pixels commandé par des registres](images/aff-8x16.svg "Afficheur 8×16 pixels commandé par des registres"){ width=95% }
+![Afficheur 8×16 pixels commandé par des registres](images/aff-8x16.svg "Afficheur 8×16 pixels commandé par des registres"){ width=95% }
 
-L'envoi des données dans les registres série-parallèle se fait selon le diagramme des temps suivant :
+L’envoi des données dans les registres série-parallèle se fait selon le diagramme des temps suivant :
 
-![Envoi des données à l'afficheur](images/reg-ser-par-timing-s.svg "Envoi des données à l'afficheur"){ width=70% }
+![Envoi des données à l’afficheur](images/reg-ser-par-timing-s.svg "Envoi des données à l’afficheur"){ width=70% }
 
 ## Augmentation du nombre de LED ##
 
-Lorsque le nombre de LED augmente, le nombre de registres augmente aussi. Ainsi un afficheur de 32 fois 32 pixels nécessite 1024 sorties de registre. En utilisant le registre classique 74HC595, il faut 128 circuits intégrés et 1024 résistances. Ces nombres sont multipliés par 3 pour un afficheurs couleur RGB, où un pixel est formé de trois LED.
+Lorsque le nombre de LED augmente, le nombre de registres augmente aussi. Ainsi un afficheur de 32×32 pixels nécessite 1024 sorties de registre. En utilisant le registre classique 74HC595, il faut 128 circuits intégrés et 1024 résistances. Ces nombres sont multipliés par 3 pour un afficheur couleur RGB, où un pixel est formé de trois LED.
 
-Avec l’usage de registres à 16 sorties du type SUM2016, dont les sorties sont à courant constant, une matrice de 32 x 32 pixels RGB nécessitera tout de même 192 circuits intégrés et 192 résistances.
+Avec l’usage de registres à 16 sorties du type SUM2016, dont les sorties sont à courant constant, une matrice de 32×32 pixels RGB nécessitera tout de même 192 circuits intégrés et 192 résistances.
 
 Il existe une solution qui limite beaucoup le nombre des registres : c’est l’usage du multiplexage temporel. Notons dès maintenant que cette solution aura des conséquences sur la luminosité de l’afficheur.
 
 ## Regroupement des anodes et des cathodes par direction ##
 
-Pour simplifier le câblage, examinons la solution qui consiste à regrouper les anodes de LED alignées dans une direction et les cathodes des LED alignées dans l'autre direction. Pour illustrer simplement notre propos, choisissons de réaliser un petit afficheur matriciel de 4 lignes de 8 pixels .Voici comment les LED vont être connectées :
+Pour simplifier le câblage, examinons la solution qui consiste à regrouper les anodes de LED alignées dans une direction et les cathodes des LED alignées dans l’autre direction. Pour illustrer simplement notre propos, choisissons de réaliser un petit afficheur matriciel de 4 lignes de 8 pixels. Voici comment les LED vont être connectées :
 
-![Matrice de 4x8 LED](images/matrice-mux-4x8.svg "Matrice de 4x8 LED"){ width=70% }
+![Matrice de 4×8 LED](images/matrice-mux-4x8.svg "Matrice de 4×8 LED"){ width=70% }
 
 ## Multiplexage temporel ##
 
-Il est impossible d'allumer en même temps certaines LED sans en allumer d'autres LED non souhaitées. Dans l'exemple suivant, on souhaite allumer les LED de coordonnées [1,1] et [3,2]. En alimentant les lignes et colonnes correspondantes, on voit qu'on allume aussi les LED [3,1] et [1,2] :
+Il est impossible d’allumer en même temps certaines LED sans en allumer d’autres non souhaitées. Dans l’exemple suivant, on souhaite allumer les LED de coordonnées [1,1] et [3,2]. En alimentant les lignes et colonnes correspondantes, on voit qu’on allume aussi les LED [3,1] et [1,2] :
 
 ![Allumages non souhaités](images/matrice-mux-4x8-2all.svg "Allumages non souhaités]"){ width=70% }
 
 Mais il est possible de commander cette matrice de LED selon le principe du multiplexage temporel, présenté dans une leçon précédente. Le multiplexage temporel consiste à afficher successivement certaines parties de l’afficheur, à une vitesse telle que l’œil ne s’en rende pas compte. Voici le diagramme des temps correspondant :
 
-![Diagramme des temps d'un afficheur 4x8 multiplexé](images/timing-8x4.svg "Diagramme des temps d'un afficheur 4x8 multiplexé"){ width=100% }
+![Diagramme des temps d’un afficheur 4×8 multiplexé](images/timing-8x4.svg "Diagramme des temps d’un afficheur 4×8 multiplexé"){ width=100% }
 
 ainsi que le schéma correspondant :
 
-![Afficheur 4x8 multiplexé](images/aff-4x8-mux.svg "Afficheur 4x8 multiplexé"){ width=70% }
+![Afficheur 4×8 multiplexé](images/aff-4x8-mux.svg "Afficheur 4×8 multiplexé"){ width=70% }
 
-Pour un cycle complet de la matrice, le registres série-parallèle doit être chargé pour chacune des lignes, nécessitant chaque fois huit coups d'horloge série et un coup d'horloge parallèle. Une fois les données d'une ligne présentes sur la sortie du registre, les anodes de la ligne correspondante doit être sélectionnée. Pour un rafraîchissement de la matrice à 100 Hz, il faudra prévoir un temps d'affichage de 25 ms pour chacune des quatre lignes.
+Pour un cycle complet de la matrice, le registre série-parallèle doit être chargé pour chacune des lignes, nécessitant chaque fois huit coups d’horloge série et un coup d’horloge parallèle. Une fois les données d’une ligne présentes sur la sortie du registre, les anodes de la ligne correspondante doivent être sélectionnées. Pour un rafraîchissement de la matrice à 100 Hz, il faudra prévoir un temps d’affichage de 25 ms pour chacune des quatre lignes.
 
-Ou voit sur le schéma que le nombre de registres a diminué : dans ce cas, il n’en reste qu’un. Par contre, il est nécessaire de pouvoir sélectionner les lignes séparément. D'autre part, il faut de placer un élément d’amplification, pour pouvoir fournir un courant suffisant pour l'ensemble les LED de la ligne. Nous avons utilisé ici un transistor PNP. Un transistor MOS à canal P est très souvent utilisé.
+On voit sur le schéma que le nombre de registres a diminué : dans ce cas, il n’en reste qu’un. Par contre, il est nécessaire de pouvoir sélectionner les lignes séparément. D’autre part, il faut placer un élément d’amplification, pour pouvoir fournir un courant suffisant pour l’ensemble les LED de la ligne. Nous avons utilisé ici un transistor PNP. Un transistor MOS à canal P est très souvent utilisé.
 
-Notons que dans ce montage, tous les signaux sont actifs à zéro. En effet, c'est bien une tension de 0 V qui permet de faire conduire le transistor PNP, en appliquant une tension négative entre sa base et son émetteur. C'est aussi une tension négative à la sortie du registre qui va allumer la LED correspondante sur la ligne sélectionnée.
+Notons que dans ce montage, tous les signaux sont actifs à zéro. En effet, c’est bien une tension de 0 V qui permet de faire conduire le transistor PNP, en appliquant une tension négative entre sa base et son émetteur. C’est aussi une tension négative à la sortie du registre qui va allumer la LED correspondante sur la ligne sélectionnée.
 
 ## Multiplexeur ##
 
 Pour éviter le grand nombre de signaux de sélection des lignes, un multiplexeur est souvent utilisé. Ce circuit combinatoire est aussi appelé un décodeur. Ses entrées correspondent aux valeurs binaires. Une seule de ses sorties peut être activée à un instant donné. Le circuit intégré 74HC138 est très souvent utilisé :
 
-![Décodeur à 8 sorties 74HC138](images/mux-138.svg "Décodeur à 8 sorties 74HC138"){ width=40% }
+![Décodeur à 8 sorties 74HC138](images/mux-138.svg "Décodeur à 8 sorties 74HC138"){ width=40% }
 
-Le fait que les sorties soient actives à zéro convient bien pour la commande des transistors PNP. L'entrée **OE** (*Output Enable*) permet d'activer l'affichage.
+Le fait que les sorties soient actives à zéro convient bien pour la commande des transistors PNP. L’entrée **OE** (*Output Enable*) permet d’activer l’affichage.
 
 ## Courant nominal et courant maximal ##
 
-Le multiplexage offre une diminution du nombre de composants nécessaires à l’électronique de commande, mais il diminue l’intensité résultante de l’afficheur. Cet effet est en partie limité par l'augmentation possible du courant dans les LED. En effet, on peut jouer sur le fait que le courant nominal des LED peut être dépassé lorsque que ce courant n’est pas permanent, ce qui est toujours le cas sur un afficheur multiplexé. Le courant pouvant aller jusqu’à une valeur proche du **courant maximal** accepté par la LED, l’intensité instantanée est sensiblement augmentée. On utilise très souvent 150% du courant nominal.
+Le multiplexage offre une diminution du nombre de composants nécessaires à l’électronique de commande, mais il diminue l’intensité résultante de l’afficheur. Cet effet est en partie limité par l’augmentation possible du courant dans les LED. En effet, on peut jouer sur le fait que le courant nominal des LED peut être dépassé lorsque ce courant n’est pas permanent, ce qui est toujours le cas sur un afficheur multiplexé. Le courant pouvant aller jusqu’à une valeur proche du **courant maximal** accepté par la LED, l’intensité instantanée est sensiblement augmentée. On utilise très souvent 150% du courant nominal.
 
 ## Comparaisons des architectures ##
 
-Un multiplexage par deux ne perd que très peu d’intensité. Il était très souvent utilisé dans les modules constituant les panneaux utilisés pour les écran vidéos géants. Il divise pas deux le nombre de registres, mais nécessite l'usage d'amplificateurs sur les anodes. Avec la baisse du prix des registres, cette solution est de moins en moins utilisée.
+Un multiplexage par deux ne perd que très peu d’intensité. Il était très souvent utilisé dans les modules constituant les panneaux utilisés pour les écrans vidéos géants. Il divise pas deux le nombre de registres, mais nécessite l’usage d’amplificateurs sur les anodes. Avec la baisse du prix des registres, cette solution est de moins en moins utilisée.
 
-Par contre, les valeurs 4, 8 et 16 se rencontrent fréquemment, vu que le prix de revient d’un module diminue lorsque le chiffre du multiplexage augmente. Mais il faut bien rester conscient de l’incidence du multiplexage sur la luminosité de l’afficheur, en particulier lorsque celui-ci doit être utilisé à l'extérieur (*outdoor*).
+Par contre, les valeurs 4, 8 et 16 se rencontrent fréquemment, vu que le prix de revient d’un module diminue lorsque le chiffre du multiplexage augmente. Mais il faut bien rester conscient de l’incidence du multiplexage sur la luminosité de l’afficheur, en particulier lorsque celui-ci doit être utilisé à l’extérieur (*outdoor*).
 
-Il faut aussi noter un point faible des afficheurs multiplexés. Dans cas d'une panne d'une LED, l'affichage peut être affecté sur des LED voisines.
+Il faut aussi noter un point faible des afficheurs multiplexés. En cas de panne d’une LED, l’affichage peut être affecté sur des LED voisines.
 
-Avec un peu d'habitude, on peut reconnaître la valeur du multiplexage en observant le circuit imprimé d'une matrice à LED. La géométrie de la matrice permet de calculer le nombre de LED présentes, en tenant compte des LED de chaque couleur pour chaque pixel. Le comptage des registres se fera en repérant et en comptant les circuits intégrés. En divisant le nombre de LED par le nombre de sorties de registres, on aura le chiffre du multiplexage. Une confirmation pourra être obtenue en observant des amplificateurs qui commandent les anodes, se présentant souvent sous forme de circuits intégrés à 8 broches, contenant chacun deux transistors P-MOS. La présence des décodeurs 74HC138 sera une confirmation supplémentaire du multiplexage. On trouvera en plus très souvent des circuits 74HC245, qui n'ont pas de rôle logique, mais qui servent à amplifier les signaux entre le connecteur d'entrée et le connecteur de sortie. Les signaux sont effet transmis d'une matrice vers la suivante pas ce moyen. 
+Avec un peu d’habitude, on peut reconnaître la valeur du multiplexage en observant le circuit imprimé d’une matrice à LED. La géométrie de la matrice permet de calculer le nombre de LED présentes, en tenant compte des LED de chaque couleur pour chaque pixel. Le comptage des registres se fera en repérant et en comptant les circuits intégrés. En divisant le nombre de LED par le nombre de sorties de registres, on aura le chiffre du multiplexage. Une confirmation pourra être obtenue en observant des amplificateurs qui commandent les anodes, se présentant souvent sous forme de circuits intégrés à 8 broches, contenant chacun deux transistors P-MOS. La présence des décodeurs 74HC138 sera une confirmation supplémentaire du multiplexage. On trouvera en plus très souvent des circuits 74HC245, qui n’ont pas de rôle logique, mais qui servent à amplifier les signaux entre le connecteur d’entrée et le connecteur de sortie. Les signaux sont effet transmis d’une matrice vers la suivante par ce moyen.
 
 ## Programmation ##
 
-Le programmation des afficheurs matriciels multiplexés est similaire à cette des afficheurs matriciels non-multiplexés. On utilise le principe de génération - rafraîchissement.
+La programmation des afficheurs matriciels multiplexés est similaire à celle des afficheurs matriciels non multiplexés. On utilise le principe de génération-rafraîchissement.
 
-Avec un afficheur non multiplexé, il suffit d'attendre pour laisser affiché un motif un certain temps. Par contre, pour un afficheur multiplexé, il est nécessaire d'exécuter des cycles d'affichage en permanence, même si le contenu le change pas.
+Avec un afficheur non multiplexé, il suffit d’attendre pour laisser un motif affiché un certain temps. Par contre, pour un afficheur multiplexé, il est nécessaire d’exécuter des cycles d’affichage en permanence, même si le contenu ne change pas.
 
-Nous pouvons donc centrer notre programme sur une procédure qui effectue un cycle complet d'affichage des lignes de l'afficheur. La durée d'un cycle est constante, par exemple environ 10 ms pour un rafraîchissement à 100 Hz. Le temps d'exécution de cette procédure peut donc devenir la base de temps pour le séquencement des animations.
+Nous pouvons donc centrer notre programme sur une procédure qui effectue un cycle complet d’affichage des lignes de l’afficheur. La durée d’un cycle est constante, par exemple environ 10 ms pour un rafraîchissement à 100 Hz. Le temps d’exécution de cette procédure peut donc devenir la base de temps pour le séquencement des animations.
 
-Pour faciliter l'écriture du programme, on passe le nombre de cycles à exécuter à la procédure d'affichage :
+Pour faciliter l’écriture du programme, on passe le nombre de cycles à exécuter à la procédure d’affichage :
 
 
 ~~~~~~~ { .c .numberLines startFrom="1" }
@@ -100,7 +100,7 @@ void CyclesMatrice(uint16_t nbCycles) {
 ~~~~~~~
 <!-- retour au mode normal pour l'éditeur -->
 
-Pour le reste, la programmation d'un afficheur multiplexé est la même que celle d'un afficheur non multiplexé. Par exemple, la procédure qui affiche un point qui rebondit sur les bords devient la suivante :
+Pour le reste, la programmation d’un afficheur multiplexé est la même que celle d’un afficheur non multiplexé. Par exemple, la procédure qui affiche un point qui rebondit sur les bords devient la suivante :
 
 ~~~~~~~ { .c .numberLines startFrom="1" }
 void Ping() {
@@ -123,7 +123,7 @@ void Ping() {
 ~~~~~~~
 <!-- retour au mode normal pour l'éditeur -->
 
-Les deux lignes qu'on trouvait dans le programme pour un afficheur non multiplexé :
+Les deux lignes qu’on trouvait dans le programme pour un afficheur non multiplexé :
 
 ~~~~~~~ { .c .numberLines startFrom="1" }
     AfficheMatrice();
@@ -136,6 +136,6 @@ sont ici remplacées par :
     CycleMatrice(DELAI);
 ~~~~~~~
 
-où la valeur DELAI est exprimée en nombre de fois le temps du cycle complet, par exemple 10 ms.
+où la valeur DELAI est exprimée en nombre de fois le temps du cycle complet, par exemple 10 ms.
 
 


### PR DESCRIPTION
Voilà quelques corrections sur les cours 106/microcontroleur et 505/matrice-mux. Note que dans microcontroleur.md, il y a un mélange de “Rst” et “RST”. Ça serait bien que tu uniformises la casse.
